### PR TITLE
Tweeks to teletype emulation and testing on various browsers.

### DIFF
--- a/src/cons.js
+++ b/src/cons.js
@@ -94,6 +94,7 @@ conswrite16(a,v)
 		case 13: break;
 		default:
 			writeterminal(String.fromCharCode(v & 0x7F));
+//			writeterminal(String.fromCharCode(v & 0xFF));
 		}
 		TPS &= 0xff7f;
 		if(TPS & (1<<6))


### PR DESCRIPTION
// Updates by JGH, Apr-2021
//  CHR$127 ignored, CHR$8 backspace, CHR$9 TABs expand option
//  single-spaced lines, >CHR$96 forced to upper case, CHR$96=UKP
//  CHR$95 prints underline using half-spaced hyphen, CHR$12 formfeeds
//  BS, TAB, ESC, Ctrl-Letter return keypresses
//  BUGS: Firefox: prevents Ctrl-N, Ctrl-T, Ctrl-W, impossible to prevent this
//        Chrome: almost all CHR$<32 intercepted by browser, including ESC and BS
//        SeaMonkey: returns all control characters

See mdfs.net/tty for installed example.
